### PR TITLE
Add updateNotifier for npm

### DIFF
--- a/lib/modules/npm.js
+++ b/lib/modules/npm.js
@@ -2,7 +2,12 @@ var fs = require("fs")
 var path = require("path")
 var spawn = require("child_process").spawn
 var dirname = require("../config").dirname
+var chalk = require("chalk")
 var updateNotifier = require("update-notifier")
+var stringLength = require("string-length")
+var fill = function (str, count) {
+  return Array(count + 1).join(str)
+}
 
 module.exports = function (argv, cb) {
   cb = typeof cb === "function" ? cb : false
@@ -28,10 +33,32 @@ module.exports = function (argv, cb) {
     process.stdout.write(stdout)
   })
   cmd.on("exit", function (code) {
-    updateNotifier({
-      packageName : pkg.name,
-      packageVersion : pkg.version,
-    }).notify()
+    var update = updateNotifier({
+      pkg: pkg,
+      updateCheckInterval: 1
+    }).update
+    if (update) updateCheck(update)
     if (cb) cb(code)
   })
+}
+
+function updateCheck(update) {
+  var line1 = ' Update available: ' + chalk.green.bold(update.latest) +
+    chalk.dim(' (current: ' + update.current + ')') + ' '
+  var line2 = ' Run ' + chalk.magenta('npmbrew install ' + update.latest) +
+    ' to update. '
+  var contentWidth = Math.max(stringLength(line1), stringLength(line2))
+  var line1rest = contentWidth - stringLength(line1)
+  var line2rest = contentWidth - stringLength(line2)
+  var top = chalk.green('┌' + fill('─', contentWidth) + '┐')
+  var bottom = chalk.green('└' + fill('─', contentWidth) + '┘')
+  var side = chalk.green('│')
+
+  var message =
+    '\n\n' +
+    top + '\n' +
+    side + line1 + fill(' ', line1rest) + side + '\n' +
+    side + line2 + fill(' ', line2rest) + side + '\n' +
+    bottom + '\n'
+  console.error(message);
 }

--- a/lib/modules/npm.js
+++ b/lib/modules/npm.js
@@ -2,6 +2,7 @@ var fs = require("fs")
 var path = require("path")
 var spawn = require("child_process").spawn
 var dirname = require("../config").dirname
+var updateNotifier = require("update-notifier")
 
 module.exports = function (argv, cb) {
   cb = typeof cb === "function" ? cb : false
@@ -27,6 +28,10 @@ module.exports = function (argv, cb) {
     process.stdout.write(stdout)
   })
   cmd.on("exit", function (code) {
+    updateNotifier({
+      packageName : pkg.name,
+      packageVersion : pkg.version,
+    }).notify()
     if (cb) cb(code)
   })
 }

--- a/lib/modules/npm.js
+++ b/lib/modules/npm.js
@@ -34,8 +34,7 @@ module.exports = function (argv, cb) {
   })
   cmd.on("exit", function (code) {
     var update = updateNotifier({
-      pkg: pkg,
-      updateCheckInterval: 1
+      pkg : pkg
     }).update
     if (update) updateCheck(update)
     if (cb) cb(code)
@@ -43,22 +42,22 @@ module.exports = function (argv, cb) {
 }
 
 function updateCheck(update) {
-  var line1 = ' Update available: ' + chalk.green.bold(update.latest) +
-    chalk.dim(' (current: ' + update.current + ')') + ' '
-  var line2 = ' Run ' + chalk.magenta('npmbrew install ' + update.latest) +
-    ' to update. '
+  var line1 = " Update available: " + chalk.green.bold(update.latest) +
+    chalk.dim(" (current: " + update.current + ")") + " "
+  var line2 = " Run " + chalk.magenta("npmbrew install " + update.latest) +
+    " to update. "
   var contentWidth = Math.max(stringLength(line1), stringLength(line2))
   var line1rest = contentWidth - stringLength(line1)
   var line2rest = contentWidth - stringLength(line2)
-  var top = chalk.green('┌' + fill('─', contentWidth) + '┐')
-  var bottom = chalk.green('└' + fill('─', contentWidth) + '┘')
-  var side = chalk.green('│')
+  var top = chalk.green("┌" + fill("─", contentWidth) + "┐")
+  var bottom = chalk.green("└" + fill("─", contentWidth) + "┘")
+  var side = chalk.green("│")
 
   var message =
-    '\n\n' +
-    top + '\n' +
-    side + line1 + fill(' ', line1rest) + side + '\n' +
-    side + line2 + fill(' ', line2rest) + side + '\n' +
-    bottom + '\n'
-  console.error(message);
+    "\n\n" +
+    top + "\n" +
+    side + line1 + fill(" ", line1rest) + side + "\n" +
+    side + line2 + fill(" ", line2rest) + side + "\n" +
+    bottom + "\n"
+  console.error(message)
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "homepage": "https://github.com/watilde/npmbrew",
   "dependencies": {
+    "chalk": "^1.0.0",
     "mkdirp": "^0.5.0",
+    "string-length": "^1.0.0",
     "text-table": "^0.2.0",
     "update-notifier": "^0.3.0"
   },


### PR DESCRIPTION
Seems nice :smirk_cat: 

```
$  ./bin/npmbrew.js npm

Usage: npm <command>

where <command> is one of:
    access, add-user, adduser, apihelp, author, bin, bugs, c,
    cache, completion, config, ddp, dedupe, deprecate, dist-tag,
    dist-tags, docs, edit, explore, faq, find, find-dupes, get,
    help, help-search, home, i, info, init, install, issues, la,
    link, list, ll, ln, login, logout, ls, outdated, owner,
    pack, prefix, prune, publish, r, rb, rebuild, remove, repo,
    restart, rm, root, run-script, s, se, search, set, show,
    shrinkwrap, star, stars, start, stop, t, tag, test, tst, un,
    uninstall, unlink, unpublish, unstar, up, update, v,
    verison, version, view, whoami

npm <cmd> -h     quick help on <cmd>
npm -l           display full usage info
npm faq          commonly asked questions
npm help <term>  search for help on <term>
npm help npm     involved overview

Specify configs in the ini-formatted file:
    /Users/watilde/.npmrc
or on the command line via: npm <command> --key value
Config info can be viewed via: npm help config

npm@2.6.0 /Users/watilde/.npmbrew/npm/v2.6.0


┌──────────────────────────────────────────┐
│ Update available: 2.7.0 (current: 2.6.0) │
│ Run npmbrew install 2.7.0 to update.     │
└──────────────────────────────────────────┘

$
```
